### PR TITLE
:sparkles: Add `dry_run` parameter to `goap::action::apply_effects`

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ class get_axe final : public action<blackboard_type> {
       return !blackboard.has_axe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.has_axe = true;
     }
 };
@@ -284,7 +284,7 @@ class chop_tree final : public action<blackboard_type> {
       return blackboard.has_axe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.wood += 1;
     }
 };

--- a/include/aitoolkit/goap.hpp
+++ b/include/aitoolkit/goap.hpp
@@ -65,7 +65,7 @@ class get_axe final : public action<blackboard_type> {
       return !blackboard.has_axe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.has_axe = true;
     }
 };
@@ -80,7 +80,7 @@ class get_pickaxe final : public action<blackboard_type> {
       return !blackboard.has_pickaxe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.has_pickaxe = true;
     }
 };
@@ -95,7 +95,7 @@ class chop_tree final : public action<blackboard_type> {
       return blackboard.has_axe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.wood += 1;
     }
 };
@@ -110,7 +110,7 @@ class mine_gold final : public action<blackboard_type> {
       return blackboard.has_pickaxe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.gold += 1;
     }
 };
@@ -125,7 +125,7 @@ class mine_stone final : public action<blackboard_type> {
       return blackboard.has_pickaxe;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.stone += 1;
     }
 };
@@ -209,7 +209,7 @@ namespace aitoolkit::goap {
       /**
        * @brief Apply the effects of this action to the blackboard.
        */
-      virtual void apply_effects(T& blackboard) const = 0;
+      virtual void apply_effects(T& blackboard, bool dry_run) const = 0;
   };
 
   /**
@@ -249,7 +249,7 @@ namespace aitoolkit::goap {
         if (!m_actions.empty()) {
           auto action = m_actions.front();
           m_actions.pop();
-          action->apply_effects(blackboard);
+          action->apply_effects(blackboard, false);
         }
       }
 
@@ -330,7 +330,7 @@ namespace aitoolkit::goap {
         for (auto& action : actions) {
           if (action->check_preconditions(current_node->blackboard)) {
             auto next_blackboard = current_node->blackboard;
-            action->apply_effects(next_blackboard);
+            action->apply_effects(next_blackboard, true);
             auto next_cost = current_node->cost + action->cost(current_node->blackboard);
 
             if (!closed_set.contains(next_blackboard)) {

--- a/tests/goap.spec.cpp
+++ b/tests/goap.spec.cpp
@@ -46,7 +46,7 @@ class chop_wood final : public action<blackboard_type> {
       return true;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.wood += 1;
     }
 };
@@ -64,7 +64,7 @@ class build_storage final : public action<blackboard_type> {
       );
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.have_storage = true;
       blackboard.wood -= 10;
     }
@@ -80,7 +80,7 @@ class gather_food final : public action<blackboard_type> {
       return blackboard.have_storage;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.food += 1;
     }
 };
@@ -95,7 +95,7 @@ class mine_gold final : public action<blackboard_type> {
       return blackboard.have_storage;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.gold += 1;
     }
 };
@@ -110,7 +110,7 @@ class mine_stone final : public action<blackboard_type> {
       return blackboard.have_storage;
     }
 
-    virtual void apply_effects(blackboard_type& blackboard) const override {
+    virtual void apply_effects(blackboard_type& blackboard, bool dry_run) const override {
       blackboard.stone += 1;
     }
 };


### PR DESCRIPTION
## Actual behavior

In the `apply_effects()` method of a GOAP action, there is no way to determine if the method is called during the planning phase, or during the plan execution phase.

## Desired behavior

Add a `bool dry_run` parameter to the method, will be `true` during the planning phase, will be `false` during the plan execution phase.