### PR TITLE
:recycle: :boom: Fix memory ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Create your simple state machine:
 auto simple_bb = blackboard_type{};
 auto simple_fsm = simple_machine<blackboard_type>();
 
-simple_fsm.set_state(std::make_shared<state_dummy>(), simple_bb);
+simple_fsm.set_state(state_dummy{}, simple_bb);
 simple_fsm.pause(simple_bb);
 simple_fsm.resume(simple_bb);
 simple_fsm.update(simple_bb);
@@ -99,8 +99,8 @@ Or with a stack state machine:
 auto stack_bb = blackboard_type{};
 auto stack_fsm = stack_machine<blackboard_type>{};
 
-stack_fsm.push_state(std::make_shared<state_dummy>(), stack_bb);
-stack_fsm.push_state(std::make_shared<state_dummy>(), stack_bb);
+stack_fsm.push_state(state_dummy{}, stack_bb);
+stack_fsm.push_state(state_dummy{}, stack_bb);
 
 stack_fsm.update(stack_bb);
 

--- a/README.md
+++ b/README.md
@@ -299,17 +299,20 @@ class chop_tree final : public action<blackboard_type> {
 Finally, create a plan and run it:
 
 ```cpp
-auto actions = std::vector<action_ptr<blackboard_type>>{
-  std::make_shared<get_axe>(),
-  std::make_shared<chop_tree>()
-};
 auto initial = blackboard_type{};
 auto goal = blackboard_type{
   .has_axe = true,
   .wood = 3
 };
 
-auto p = planner<blackboard_type>(actions, initial, goal);
+auto p = planner<blackboard_type>(
+  action_list<blackboard_type>(
+    get_axe{},
+    chop_tree{}
+  ),
+  initial,
+  goal
+);
 
 auto blackboard = initial;
 while (p) {

--- a/README.md
+++ b/README.md
@@ -228,12 +228,14 @@ class collect_gold final : public action<blackboard_type> {
 Finally, create an evaluator and run it:
 
 ```cpp
-auto evaluator = evaluator<blackboard_type>{
-  std::make_shared<collect_food>(),
-  std::make_shared<collect_wood>(),
-  std::make_shared<collect_stone>(),
-  std::make_shared<collect_gold>()
-};
+auto evaluator = evaluator<blackboard_type>(
+  action_list<blackboard_type>(
+    collect_food{},
+    collect_wood{},
+    collect_stone{},
+    collect_gold{}
+  )
+);
 
 auto blackboard = blackboard_type{};
 evaluator.run(blackboard);

--- a/README.md
+++ b/README.md
@@ -129,16 +129,18 @@ struct blackboard_type {
 Then, create your tree:
 
 ```cpp
-auto tree = seq<blackboard_type>::make({
-  check<blackboard_type>::make([](const blackboard_type& bb) {
-    // check some condition
-    return true;
-  }),
-  task<blackboard_type>::make([](blackboard_type& bb) {
-    // perform some action
-    return execution_state::success;
-  })
-});
+auto tree = seq<blackboard_type>(
+  node_list<blackboard_type>(
+    check<blackboard_type>([](const blackboard_type& bb) {
+      // check some condition
+      return true;
+    }),
+    task<blackboard_type>([](blackboard_type& bb) {
+      // perform some action
+      return execution_state::success;
+    })
+  )
+);
 ```
 
 Finally, evaluate it:
@@ -148,7 +150,7 @@ auto blackboard = blackboard_type{
   // ...
 };
 
-auto state = tree->evaluate(blackboard);
+auto state = tree.evaluate(blackboard);
 ```
 
 For more informations, consult the

--- a/tests/behtree.spec.cpp
+++ b/tests/behtree.spec.cpp
@@ -11,11 +11,11 @@ TEST_CASE("behtree task node evaluation") {
   SUBCASE("task node returns success") {
     blackboard_type blackboard;
 
-    auto task_node = task<blackboard_type>::make([](auto& blackboard) {
+    auto task_node = task<blackboard_type>([](auto& blackboard) {
       return execution_state::success;
     });
 
-    auto state = task_node->evaluate(blackboard);
+    auto state = task_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
   }
@@ -23,11 +23,11 @@ TEST_CASE("behtree task node evaluation") {
   SUBCASE("task node returns failure") {
     blackboard_type blackboard;
 
-    auto task_node = task<blackboard_type>::make([](auto& blackboard) {
+    auto task_node = task<blackboard_type>([](auto& blackboard) {
       return execution_state::failure;
     });
 
-    auto state = task_node->evaluate(blackboard);
+    auto state = task_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
   }
@@ -35,11 +35,11 @@ TEST_CASE("behtree task node evaluation") {
   SUBCASE("task node returns running") {
     blackboard_type blackboard;
 
-    auto task_node = task<blackboard_type>::make([](auto& blackboard) {
+    auto task_node = task<blackboard_type>([](auto& blackboard) {
       return execution_state::running;
     });
 
-    auto state = task_node->evaluate(blackboard);
+    auto state = task_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
   }
@@ -49,11 +49,11 @@ TEST_CASE("behtree check node evaluation") {
   SUBCASE("check node returns success") {
     blackboard_type blackboard;
 
-    auto check_node = check<blackboard_type>::make([](auto& blackboard) {
+    auto check_node = check<blackboard_type>([](auto& blackboard) {
       return true;
     });
 
-    auto state = check_node->evaluate(blackboard);
+    auto state = check_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
   }
@@ -61,11 +61,11 @@ TEST_CASE("behtree check node evaluation") {
   SUBCASE("check node returns failure") {
     blackboard_type blackboard;
 
-    auto check_node = check<blackboard_type>::make([](auto& blackboard) {
+    auto check_node = check<blackboard_type>([](auto& blackboard) {
       return false;
     });
 
-    auto state = check_node->evaluate(blackboard);
+    auto state = check_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
   }
@@ -75,13 +75,13 @@ TEST_CASE("behtree neg node evaluation") {
   SUBCASE("neg node returns success") {
     blackboard_type blackboard;
 
-    auto neg_node = neg<blackboard_type>::make(
-      task<blackboard_type>::make([](auto& blackboard) {
+    auto neg_node = neg<blackboard_type>(
+      task<blackboard_type>([](auto& blackboard) {
         return execution_state::failure;
       })
     );
 
-    auto state = neg_node->evaluate(blackboard);
+    auto state = neg_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
   }
@@ -89,13 +89,13 @@ TEST_CASE("behtree neg node evaluation") {
   SUBCASE("neg node returns failure") {
     blackboard_type blackboard;
 
-    auto neg_node = neg<blackboard_type>::make(
-      task<blackboard_type>::make([](auto& blackboard) {
+    auto neg_node = neg<blackboard_type>(
+      task<blackboard_type>([](auto& blackboard) {
         return execution_state::success;
       })
     );
 
-    auto state = neg_node->evaluate(blackboard);
+    auto state = neg_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
   }
@@ -103,13 +103,13 @@ TEST_CASE("behtree neg node evaluation") {
   SUBCASE("neg node returns running") {
     blackboard_type blackboard;
 
-    auto neg_node = neg<blackboard_type>::make(
-      task<blackboard_type>::make([](auto& blackboard) {
+    auto neg_node = neg<blackboard_type>(
+      task<blackboard_type>([](auto& blackboard) {
         return execution_state::running;
       })
     );
 
-    auto state = neg_node->evaluate(blackboard);
+    auto state = neg_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
   }
@@ -119,18 +119,20 @@ TEST_CASE("behtree seq node evaluation") {
   SUBCASE("seq node returns success") {
     blackboard_type blackboard;
 
-    auto seq_node = seq<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      })
-    });
+    auto seq_node = seq<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        })
+      )
+    );
 
-    auto state = seq_node->evaluate(blackboard);
+    auto state = seq_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
     CHECK(blackboard.node_count == 2);
@@ -139,18 +141,20 @@ TEST_CASE("behtree seq node evaluation") {
   SUBCASE("seq node returns failure") {
     blackboard_type blackboard;
 
-    auto seq_node = seq<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      })
-    });
+    auto seq_node = seq<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        })
+      )
+    );
 
-    auto state = seq_node->evaluate(blackboard);
+    auto state = seq_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
     CHECK(blackboard.node_count == 2);
@@ -159,18 +163,20 @@ TEST_CASE("behtree seq node evaluation") {
   SUBCASE("seq node returns failure early") {
     blackboard_type blackboard;
 
-    auto seq_node = seq<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      })
-    });
+    auto seq_node = seq<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        })
+      )
+    );
 
-    auto state = seq_node->evaluate(blackboard);
+    auto state = seq_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
     CHECK(blackboard.node_count == 1);
@@ -179,18 +185,20 @@ TEST_CASE("behtree seq node evaluation") {
   SUBCASE("seq node returns running") {
     blackboard_type blackboard;
 
-    auto seq_node = seq<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::running;
-      })
-    });
+    auto seq_node = seq<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::running;
+        })
+      )
+    );
 
-    auto state = seq_node->evaluate(blackboard);
+    auto state = seq_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
     CHECK(blackboard.node_count == 2);
@@ -199,18 +207,20 @@ TEST_CASE("behtree seq node evaluation") {
   SUBCASE("seq node returns running early") {
     blackboard_type blackboard;
 
-    auto seq_node = seq<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::running;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      })
-    });
+    auto seq_node = seq<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::running;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        })
+      )
+    );
 
-    auto state = seq_node->evaluate(blackboard);
+    auto state = seq_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
     CHECK(blackboard.node_count == 1);
@@ -221,18 +231,20 @@ TEST_CASE("behtree sel node evaluation") {
   SUBCASE("sel node returns success when one child succeeds") {
     blackboard_type blackboard;
 
-    auto sel_node = sel<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      })
-    });
+    auto sel_node = sel<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        })
+      )
+    );
 
-    auto state = sel_node->evaluate(blackboard);
+    auto state = sel_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
     CHECK(blackboard.node_count == 2);
@@ -241,18 +253,20 @@ TEST_CASE("behtree sel node evaluation") {
   SUBCASE("sel node returns success when one child succeeds early") {
     blackboard_type blackboard;
 
-    auto sel_node = sel<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::success;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      })
-    });
+    auto sel_node = sel<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::success;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        })
+      )
+    );
 
-    auto state = sel_node->evaluate(blackboard);
+    auto state = sel_node.evaluate(blackboard);
 
     CHECK(state == execution_state::success);
     CHECK(blackboard.node_count == 1);
@@ -261,18 +275,20 @@ TEST_CASE("behtree sel node evaluation") {
   SUBCASE("sel node return failure when all children fail") {
     blackboard_type blackboard;
 
-    auto sel_node = sel<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      })
-    });
+    auto sel_node = sel<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        })
+      )
+    );
 
-    auto state = sel_node->evaluate(blackboard);
+    auto state = sel_node.evaluate(blackboard);
 
     CHECK(state == execution_state::failure);
     CHECK(blackboard.node_count == 2);
@@ -281,18 +297,20 @@ TEST_CASE("behtree sel node evaluation") {
   SUBCASE("sel node returns running when one child returns running") {
     blackboard_type blackboard;
 
-    auto sel_node = sel<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::running;
-      })
-    });
+    auto sel_node = sel<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::running;
+        })
+      )
+    );
 
-    auto state = sel_node->evaluate(blackboard);
+    auto state = sel_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
     CHECK(blackboard.node_count == 2);
@@ -301,18 +319,20 @@ TEST_CASE("behtree sel node evaluation") {
   SUBCASE("sel node returns running when one child returns running early") {
     blackboard_type blackboard;
 
-    auto sel_node = sel<blackboard_type>::make({
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::running;
-      }),
-      task<blackboard_type>::make([](auto& blackboard) {
-        blackboard.node_count++;
-        return execution_state::failure;
-      })
-    });
+    auto sel_node = sel<blackboard_type>(
+      node_list<blackboard_type>(
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::running;
+        }),
+        task<blackboard_type>([](auto& blackboard) {
+          blackboard.node_count++;
+          return execution_state::failure;
+        })
+      )
+    );
 
-    auto state = sel_node->evaluate(blackboard);
+    auto state = sel_node.evaluate(blackboard);
 
     CHECK(state == execution_state::running);
     CHECK(blackboard.node_count == 1);

--- a/tests/fsm.spec.cpp
+++ b/tests/fsm.spec.cpp
@@ -44,7 +44,7 @@ TEST_CASE("fsm simple machine") {
   auto blackboard = blackboard_type{};
   auto fsm = simple_machine<blackboard_type>{};
 
-  fsm.set_state(std::make_shared<state_dummy>(1), blackboard);
+  fsm.set_state(state_dummy{1}, blackboard);
   CHECK(blackboard.enter == 1);
 
   fsm.pause(blackboard);
@@ -56,15 +56,15 @@ TEST_CASE("fsm simple machine") {
   fsm.update(blackboard);
   CHECK(blackboard.update == 1);
 
-  fsm.set_state(std::make_shared<state_dummy>(2), blackboard);
+  fsm.set_state(state_dummy{2}, blackboard);
   CHECK(blackboard.exit == 1);
   CHECK(blackboard.enter == 2);
 
-  fsm.set_state(nullptr, blackboard);
+  fsm.clear_state(blackboard);
   CHECK(blackboard.exit == 2);
 
   fsm.pause(blackboard);
-  fsm.set_state(std::make_shared<state_dummy>(3), blackboard);
+  fsm.set_state(state_dummy{3}, blackboard);
   CHECK(blackboard.enter == 3);
   CHECK(blackboard.pause == 3);
 }
@@ -73,10 +73,10 @@ TEST_CASE("fsm stack machine") {
   auto blackboard = blackboard_type{};
   auto fsm = stack_machine<blackboard_type>{};
 
-  fsm.push_state(std::make_shared<state_dummy>(1), blackboard);
+  fsm.push_state(state_dummy{1}, blackboard);
   CHECK(blackboard.enter == 1);
 
-  fsm.push_state(std::make_shared<state_dummy>(2), blackboard);
+  fsm.push_state(state_dummy{2}, blackboard);
   CHECK(blackboard.enter == 2);
   CHECK(blackboard.pause == 1);
 

--- a/tests/goap.spec.cpp
+++ b/tests/goap.spec.cpp
@@ -132,16 +132,17 @@ TEST_CASE("goap planning") {
       .gold = 2,
       .stone = 1
     };
-
-    auto actions = std::vector<action_ptr<blackboard_type>>{
-      std::make_shared<chop_wood>(),
-      std::make_shared<build_storage>(),
-      std::make_shared<gather_food>(),
-      std::make_shared<mine_gold>(),
-      std::make_shared<mine_stone>()
-    };
-
-    auto p = planner<blackboard_type>(actions, initial, goal);
+    auto p = planner<blackboard_type>(
+      action_list<blackboard_type>(
+        chop_wood{},
+        build_storage{},
+        gather_food{},
+        mine_gold{},
+        mine_stone{}
+      ),
+      initial,
+      goal
+    );
     CHECK(p);
 
     // 10 chop wood, 1 build storage, 3 gather food, 2 mine gold, 1 mine stone
@@ -170,15 +171,18 @@ TEST_CASE("goap planning") {
       .stone = 1
     };
 
-    auto actions = std::vector<action_ptr<blackboard_type>>{
-      std::make_shared<chop_wood>(),
-      std::make_shared<build_storage>(),
-      std::make_shared<gather_food>(),
-      std::make_shared<mine_gold>(),
-      std::make_shared<mine_stone>()
-    };
-
-    auto p = planner<blackboard_type>(actions, initial, goal, 1000);
+    auto p = planner<blackboard_type>(
+      action_list<blackboard_type>(
+        chop_wood{},
+        build_storage{},
+        gather_food{},
+        mine_gold{},
+        mine_stone{}
+      ),
+      initial,
+      goal,
+      1000
+    );
     CHECK(!p);
   }
 }

--- a/tests/utility.spec.cpp
+++ b/tests/utility.spec.cpp
@@ -14,13 +14,8 @@ struct blackboard_type {
 };
 
 TEST_CASE("utility evaluator") {
-
   class action_a final : public action<blackboard_type> {
     public:
-      static action_ptr<blackboard_type> make() {
-        return std::make_shared<action_a>();
-      }
-
       virtual float score(const blackboard_type& blackboard) const override {
         return 1.0f;
       }
@@ -32,10 +27,6 @@ TEST_CASE("utility evaluator") {
 
   class action_b final : public action<blackboard_type> {
     public:
-      static action_ptr<blackboard_type> make() {
-        return std::make_shared<action_b>();
-      }
-
       virtual float score(const blackboard_type& blackboard) const override {
         return 2.0f;
       }
@@ -47,10 +38,6 @@ TEST_CASE("utility evaluator") {
 
   class action_c final : public action<blackboard_type> {
     public:
-      static action_ptr<blackboard_type> make() {
-        return std::make_shared<action_c>();
-      }
-
       virtual float score(const blackboard_type& blackboard) const override {
         return 3.0f;
       }
@@ -62,11 +49,13 @@ TEST_CASE("utility evaluator") {
 
   SUBCASE("evaluator runs action with highest score") {
     blackboard_type blackboard;
-    auto machine = evaluator<blackboard_type>{
-      action_a::make(),
-      action_b::make(),
-      action_c::make(),
-    };
+    auto machine = evaluator<blackboard_type>(
+      action_list<blackboard_type>(
+        action_a{},
+        action_b{},
+        action_c{}
+      )
+    );
 
     machine.run(blackboard);
 


### PR DESCRIPTION
## Actual behavior

The use of `std::shared_ptr` was unfortunate. I initially had trouble with `std::unique_ptr`:

 - it is impossible to iterate over an `std::initializer_list<std::unique_ptr<T>>` as it always make a copy
 - the constructor of `std::vector<std::unique_ptr<T>>` make use of `std::initializer_list`

## Desired behavior

The data should be owned by the modules, and `std::shared_ptr` does not indicate that.

## Changes

**FSM:**

 - [x] :recycle: :boom: Use `std::unique_ptr` instead of `std::shared_ptr`
 - [x] :sparkles: Add `state_trait` concept
 - [x] :recycle: :boom: The `simple_machine::set_state()` transition now accepts a value that satisfies `state_trait`, it will be copied in an internal `std::unique_ptr`
 - [x] :sparkles: Adds a `simple_machine::clear_state()` transition
 - [x] :recycle: :boom: The `stack_machine::push_state()` transition now accepts a value that satisfies `state_trait`, it will be copied in an internal `std::unique_ptr`

**Behavior Tree:**

 - [x] :recycle: :boom: Use `std::unique_ptr` instead of `std::shared_ptr`
 - [x] :sparkles: Add `node_trait` concept
 - [x] :fire: :boom: Remove all `make()` static methods
 - [x] :recycle: :boom: Replace `std::initializer_list` with `std::vector`
 - [x] :sparkles: Add `node_list()` template function helper to create the `std::vector` using a parameter pack

**Utility AI:**

 - [x] :recycle: :boom: Use `std::unique_ptr` instead of `std::shared_ptr`
 - [x] :sparkles: Add `action_trait` concept
 - [x] :recycle: :boom: Replace `std::initializer_list` with `std::vector`
 - [x] :sparkles: Add `action_list()` template function helper to create the `std::vector` using a parameter pack

**GOAP:**

 - [x] :recycle: :boom: Use `std::unique_ptr` instead of `std::shared_ptr`
 - [x] :sparkles: Add `action_trait` concept
 - [x] :recycle: :boom: Replace `std::initializer_list` with `std::vector`
 - [x] :sparkles: Add `action_list()` template function helper to create the `std::vector` using a parameter pack
 - [x] :recycle: The plan now takes ownership of the action list given to the planner, the queue is a queue of indices into  the action list, this allows to forge a reference to a `std::unique_ptr` (since an action can appear multiple times in a plan)