### PR TITLE
:bug: Fix reversed plan in GOAP

### DIFF
--- a/include/aitoolkit/goap.hpp
+++ b/include/aitoolkit/goap.hpp
@@ -171,6 +171,7 @@ while (p) {
 #include <memory>
 #include <vector>
 #include <queue>
+#include <stack>
 
 #include <type_traits>
 #include <concepts>
@@ -264,7 +265,7 @@ namespace aitoolkit::goap {
        */
       void run_next(T& blackboard) {
         if (!m_plan.empty()) {
-          auto action_idx = m_plan.front();
+          auto action_idx = m_plan.top();
           m_plan.pop();
 
           auto& action = m_actions[action_idx];
@@ -273,7 +274,7 @@ namespace aitoolkit::goap {
       }
 
     private:
-      std::queue<size_t> m_plan;
+      std::stack<size_t> m_plan;
       std::vector<action_ptr<T>> m_actions;
 
       friend plan<T> planner<T>(


### PR DESCRIPTION
## Actual Behavior

By using an `std::queue` for the plan, it ends up being reversed.

## Desired Behavior

By using an `std::stack` instead, this fixes the issue.

---

<details>
<summary>Original Message</summary>

target file : "goap.hpp"

In class plan, m_plan should be stack not queue.

In line 347 at "goap.hpp", it pushes action_idx of current_node which is latest node.

Then, in queue, it pop latest action_idx first, so the order is reversed.

I changed it to stack to pop first node's action_idx.

Please check this out. Thanks.
</details>